### PR TITLE
Pawn promote action finished

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -37,14 +37,9 @@ class GamesController < ApplicationController
 	def promote_create
 		@game = Game.find(params[:game_id])
 		@piece = Piece.find(params[:id])
-		@piece_promote = piece_type.create(:color => @piece.image, :x_axis => @piece.x_axis, :y_axis => @piece.y_axis, :image => @piece.image_select(@piece.color, params[:type]), :game_id => @game.id)
+		@piece_promote = Piece.create(:color => @piece.image, :x_axis => @piece.x_axis, :y_axis => @piece.y_axis, :image => @piece.image_select(@piece.color, params[:type]), :game_id => @game.id, :type => params[:type])
 		@piece.destroy
 		redirect_to game_path(@game)
 	end
 	
-	private
-
-	def piece_type
-		Piece.types.include?(params[:type]) ? params[:type] : "Piece"
-	end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -19,11 +19,11 @@ class GamesController < ApplicationController
 		@game = Game.find(params[:game_id])
 		@piece = Piece.find(params[:id])
 
-		if :y_axis == 0 || 7
-			@piece.update_attributes(:x_axis => params[:x_axis], :y_axis => params[:y_axis])
-			redirect_to game_promote_select_path(@game)## TODO: promote page
+		@piece.move_to!(params[:x_axis], params[:y_axis])
+
+		if @piece.y_axis == 0 || @piece.y_axis == 7
+			redirect_to game_promote_select_path(:game_id => @game, :id => @piece)## TODO: promote page
 		else
-			@piece.update_attributes(:x_axis => params[:x_axis], :y_axis => params[:y_axis])
 			redirect_to game_path(@game)
 		end
 	end
@@ -34,9 +34,17 @@ class GamesController < ApplicationController
 		@piece = Piece.find(params[:id])
 	end
 
-	def promote_update
+	def promote_create
 		@game = Game.find(params[:game_id])
 		@piece = Piece.find(params[:id])
-		@piece.update_attributes(:type => params[:type], :image=> params[:image])
+		@piece_promote = piece_type.create(:color => @piece.image, :x_axis => @piece.x_axis, :y_axis => @piece.y_axis, :image => @piece.image_select(@piece.color, params[:type]), :game_id => @game.id)
+		@piece.destroy
+		redirect_to game_path(@game)
+	end
+	
+	private
+
+	def piece_type
+		Piece.types.include?(params[:type]) ? params[:type] : "Piece"
 	end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -18,8 +18,25 @@ class GamesController < ApplicationController
 	def piece_update
 		@game = Game.find(params[:game_id])
 		@piece = Piece.find(params[:id])
-		@piece.update_attributes(:x_axis => params[:x_axis], :y_axis => params[:y_axis])
-		redirect_to game_path(@game)
+
+		if :y_axis == 0 || 7
+			@piece.update_attributes(:x_axis => params[:x_axis], :y_axis => params[:y_axis])
+			redirect_to game_promote_select_path(@game)## TODO: promote page
+		else
+			@piece.update_attributes(:x_axis => params[:x_axis], :y_axis => params[:y_axis])
+			redirect_to game_path(@game)
+		end
 	end
 
+	def promote_select
+		@game = Game.find(params[:game_id])
+		@board = @game.board
+		@piece = Piece.find(params[:id])
+	end
+
+	def promote_update
+		@game = Game.find(params[:game_id])
+		@piece = Piece.find(params[:id])
+		@piece.update_attributes(:type => params[:type], :image=> params[:image])
+	end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -13,18 +13,18 @@ class Piece < ActiveRecord::Base
 
 
   IMAGE = {
-    'white Rook' => 'white-rook.gif',
-    'white Knight' => 'white-knight.gif',
-    'white Bishop' => 'white-bishop.gif',
-    'white King' => 'white-king.gif',
-    'white Queen' => 'white-queen.gif',
-    'white pawn' => 'white-pawn.gif',
-    'black Rook' => 'black-rook.gif',
-    'black Knight' => 'black-knight.gif',
-    'black Bishop' => 'black-bishop.gif',
-    'black King' => 'black-king.gif',
-    'black Queen' => 'black-queen.gif',
-    'black pawn' => 'black-pawn.gif',
+    :whiteRook => 'white-rook.gif',
+    :whiteKnight => 'white-knight.gif',
+    :whiteBishop => 'white-bishop.gif',
+    :whiteKing => 'white-king.gif',
+    :whiteQueen => 'white-queen.gif',
+    :whitePawn => 'white-pawn.gif',
+    :blackRook => 'black-rook.gif',
+    :blackKnight => 'black-knight.gif',
+    :blackBishop => 'black-bishop.gif',
+    :blackKing => 'black-king.gif',
+    :blackQueen => 'black-queen.gif',
+    :blackPawn => 'black-pawn.gif'
   }
 
   def move_to!(x_axis, y_axis)#Check methods piece_at() and capture()
@@ -46,6 +46,6 @@ class Piece < ActiveRecord::Base
   end
 
   def image_select(color, type)
-    IMAGE["#{color} #{type}"]
+    IMAGE["#{color}#{type}".to_sym]
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -12,6 +12,21 @@ class Piece < ActiveRecord::Base
   scope :pawns, -> {where(type: 'Pawn') }
 
 
+  IMAGE = {
+    'white Rook' => 'white-rook.gif',
+    'white Knight' => 'white-knight.gif',
+    'white Bishop' => 'white-bishop.gif',
+    'white King' => 'white-king.gif',
+    'white Queen' => 'white-queen.gif',
+    'white pawn' => 'white-pawn.gif',
+    'black Rook' => 'black-rook.gif',
+    'black Knight' => 'black-knight.gif',
+    'black Bishop' => 'black-bishop.gif',
+    'black King' => 'black-king.gif',
+    'black Queen' => 'black-queen.gif',
+    'black pawn' => 'black-pawn.gif',
+  }
+
   def move_to!(x_axis, y_axis)#Check methods piece_at() and capture()
   	if self.game.piece_at(x_axis, y_axis).nil? 
       update_attributes(:x_axis => x_axis, :y_axis => y_axis)
@@ -28,5 +43,9 @@ class Piece < ActiveRecord::Base
     captured = self.game.pieces.where(:x_axis => target_x_axis, :y_axis => target_y_axis).first
     captured.update_attributes(:x_axis => nil, :y_axis => nil)
     update_attributes(:x_axis => target_x_axis, :y_axis => target_y_axis)
+  end
+
+  def image_select(color, type)
+    IMAGE["#{color} #{type}"]
   end
 end

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -11,6 +11,7 @@ class Piece < ActiveRecord::Base
   scope :queens, -> {where(type: 'Queen') }
   scope :pawns, -> {where(type: 'Pawn') }
 
+
   def move_to!(x_axis, y_axis)#Check methods piece_at() and capture()
   	if self.game.piece_at(x_axis, y_axis).nil? 
       update_attributes(:x_axis => x_axis, :y_axis => y_axis)

--- a/app/models/piece.rb
+++ b/app/models/piece.rb
@@ -67,6 +67,7 @@ class Piece < ActiveRecord::Base
 
   def image_select(color, type)
     IMAGE["#{color}#{type}".to_sym]
+  end
 
   # define some helper methods for move validation
   def ensure_reasonable_move!(position_2)

--- a/app/views/games/promote_select.html.erb
+++ b/app/views/games/promote_select.html.erb
@@ -1,10 +1,13 @@
-<div class = 'col-xs-10 col-xs-offset-1'>
+<div class = 'col-xs-2'>
+<h2>What would you like to promote your pawn to?</h2>
+<%= @piece.x_axis %>, <%= @piece.y_axis %>
+	<%= link_to 'Queen', game_promote_create_path(:type => 'Queen'), :method => 'put' %>, 
+	<%= link_to 'Rook', game_promote_create_path(:type => 'Rook'), :method => 'put' %>, 
+	<%= link_to 'Bishop', game_promote_create_path(:type => 'Bishop'), :method => 'put' %>, 
+	<%= link_to 'Knight', game_promote_create_path(:type => 'Knight'), :method => 'put' %>
+</div>
 
-<h1>What would you like to promote your pawn to?</h1>
-	<%= link_to 'Queen', game_promote_update_path(:type => ':queen', :image => 'white-queen.png') %>, 
-	<%= link_to 'Rook', game_promote_update_path(:type => ':rook', :image => 'white-rook.png') %>, 
-	<%= link_to 'Bishop', game_promote_update_path(:type => ':bishop', :image => 'white-bishop.png') %>, 
-	<%= link_to 'Knight', game_promote_update_path(:type => ':knight', :image => 'white-knight.png') %>
+<div class = 'col-xs-10 col-xs-offset-1'>
 
 	<table id = 'chess'>
 		<% @board.each_index do |y| %>

--- a/app/views/games/promote_select.html.erb
+++ b/app/views/games/promote_select.html.erb
@@ -1,0 +1,37 @@
+<div class = 'col-xs-10 col-xs-offset-1'>
+
+<h1>What would you like to promote your pawn to?</h1>
+	<%= link_to 'Queen', game_promote_update_path(:type => ':queen', :image => 'white-queen.png') %>, 
+	<%= link_to 'Rook', game_promote_update_path(:type => ':rook', :image => 'white-rook.png') %>, 
+	<%= link_to 'Bishop', game_promote_update_path(:type => ':bishop', :image => 'white-bishop.png') %>, 
+	<%= link_to 'Knight', game_promote_update_path(:type => ':knight', :image => 'white-knight.png') %>
+
+	<table id = 'chess'>
+		<% @board.each_index do |y| %>
+			<tr class = '<%= y %>' >
+				<% @board[y].each_index do |x| %>
+					<% if @board[y][x].nil? %>
+						<td class = '<%= x %>'>
+							<%= link_to game_piece_update_path(:x_axis => x, :y_axis => y), :method => 'put' do %>
+							<p>&nbsp; &nbsp; &nbsp;</p>
+							<p>&nbsp; &nbsp; &nbsp;</p>
+							<% end %>
+						</td>
+					<% elsif @board[y][x].id == @piece.id %>
+						<td class = '<%= x %> selected'>
+							<%= image_tag @piece.image %>
+						</td>
+					<% else %>
+						<td class = '<%= x %>'>
+							<%= link_to game_piece_select_path(@board[y][x].game_id, @board[y][x].id) do %>
+							<%= link_to game_piece_update_path(:x_axis => x, :y_axis => y), :method => 'put' do %>
+							<%= image_tag @board[y][x].image, :class => 'responsive' %>
+							<% end %>
+							<% end %>
+						</td>
+					<% end %>
+				<% end %>
+			</tr>
+		<% end %>
+	</table>
+</div>

--- a/app/views/games/promote_select.html.erb
+++ b/app/views/games/promote_select.html.erb
@@ -1,13 +1,12 @@
 <div class = 'col-xs-2'>
-<h2>What would you like to promote your pawn to?</h2>
-<%= @piece.x_axis %>, <%= @piece.y_axis %>
-	<%= link_to 'Queen', game_promote_create_path(:type => 'Queen'), :method => 'put' %>, 
-	<%= link_to 'Rook', game_promote_create_path(:type => 'Rook'), :method => 'put' %>, 
-	<%= link_to 'Bishop', game_promote_create_path(:type => 'Bishop'), :method => 'put' %>, 
-	<%= link_to 'Knight', game_promote_create_path(:type => 'Knight'), :method => 'put' %>
+<h4>What would you like to promote your pawn to?</h4>
+	<%= link_to 'Queen', game_promote_create_path(:type => 'Queen'), :method => 'post' %>, 
+	<%= link_to 'Rook', game_promote_create_path(:type => 'Rook'), :method => 'post' %>, 
+	<%= link_to 'Bishop', game_promote_create_path(:type => 'Bishop'), :method => 'post' %>, 
+	<%= link_to 'Knight', game_promote_create_path(:type => 'Knight'), :method => 'post' %>
 </div>
 
-<div class = 'col-xs-10 col-xs-offset-1'>
+<div class = 'col-xs-8 col-xs-offset-1'>
 
 	<table id = 'chess'>
 		<% @board.each_index do |y| %>

--- a/app/views/games/select.html.erb
+++ b/app/views/games/select.html.erb
@@ -1,5 +1,4 @@
 <div class = 'col-xs-10 col-xs-offset-1'>
-
 	<table id = 'chess'>
 		<% @board.each_index do |y| %>
 			<tr class = '<%= y %>' >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     get '/select/pieces/:id', to: 'games#select', as: :piece_select
     put '/select/pieces/:id/:y_axis/:x_axis', to: 'games#piece_update', as: :piece_update
     get '/select/pieces/:id/promote', to: 'games#promote_select', as: :promote_select
-    put '/select/pieces/:id/promote/:type/:image', to: 'games#promote_update', as: :promote_update
+    put '/select/pieces/:id/promote/:type', to: 'games#promote_create', as: :promote_create
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
     get '/select/pieces/:id', to: 'games#select', as: :piece_select
     put '/select/pieces/:id/:y_axis/:x_axis', to: 'games#piece_update', as: :piece_update
     get '/select/pieces/:id/promote', to: 'games#promote_select', as: :promote_select
-    put '/select/pieces/:id/promote/:type', to: 'games#promote_create', as: :promote_create
+    post '/select/pieces/:id/promote/:type', to: 'games#promote_create', as: :promote_create
   end
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,10 +5,10 @@ Rails.application.routes.draw do
   resources :games
 
   resources :games, :only => [:show] do
-
     get '/select/pieces/:id', to: 'games#select', as: :piece_select
     put '/select/pieces/:id/:y_axis/:x_axis', to: 'games#piece_update', as: :piece_update
-
+    get '/select/pieces/:id/promote', to: 'games#promote_select', as: :promote_select
+    put '/select/pieces/:id/promote/:type/:image', to: 'games#promote_update', as: :promote_update
   end
 
 

--- a/test/controllers/games_controller_test.rb
+++ b/test/controllers/games_controller_test.rb
@@ -39,4 +39,22 @@ class GamesControllerTest < ActionController::TestCase
 	   	assert_equal expected_coord, actual_coord
 	end
 
+	test 'pawn_promote' do
+		game = Game.create(:user_id => 1)
+	   	game.populate_board
+	   	board = game.board
+	   	pawn = board[1][0]
+
+	   	put :piece_update, :game_id => game.id, :id => pawn.id, :y_axis => 7, :x_axis => 0
+	
+
+	   	post :promote_create, :game_id => game.id, :id => pawn.id, :type => 'Queen'
+
+	   	pawn_promoted = Piece.where(:y_axis => board[7][0].y_axis, :x_axis => board[7][0].x_axis).first
+	   	expected_type = 'Queen'
+	   	actual_type = pawn_promoted.type
+
+	   	assert_equal expected_type, actual_type
+	end
+
 end


### PR DESCRIPTION
Now have finished pawn promote action and added new test. The promote action takes the player to a promote selection page if they pawn reaches 0 or 7 y_axis, where player can choose what they would like to promote the pawn to. Once selected, a new piece (of the type) will be created with the location of the pawn piece, and the pawn piece will be destroyed. A new piece is created because with STI, you cannot change the actual pawn into a different model piece class (even if you change the type, the actual class still stays the same as pawn (unless there is a different way to update/change the piece?).

Note: The logic used to take the player to the promote page is simple because it is assumed that once the "valid_move?" is hooked up, pawns will only be able to advance forward so will never be in the end rows of the sides where they came from. (i.e. white pawns will never be in y_axis "0" and black pawns will never be in y_axis "7").
